### PR TITLE
Testing Mock API

### DIFF
--- a/tests/sauceDemo/api/data/books.json
+++ b/tests/sauceDemo/api/data/books.json
@@ -1,0 +1,15 @@
+{
+    "books": [
+        {
+            "isbn": "9781449337711",
+            "title": "Designing Evolvable Web APIs with ASP.NET",
+            "subTitle": "Harnessing the Power of the Web",
+            "author": "Glenn Block et al.",
+            "publish_date": "2020-06-04T09:12:43.000Z",
+            "publisher": "O'Reilly Media",
+            "pages": 238,
+            "description": "Design and build Web APIs for a...",
+            "website": "https://chimera.labs.oreilly.com/books/..."
+        }
+    ]
+}

--- a/tests/sauceDemo/api/test_books.py
+++ b/tests/sauceDemo/api/test_books.py
@@ -1,0 +1,22 @@
+import pytest
+from typing import Generator
+from playwright.sync_api import Playwright, sync_playwright, Page, APIRequestContext, expect
+from sauceUtils.data import SauceDemoData
+
+"""TESTING WITH MOCK API"""
+def test_select_single_book(page):
+    """Using a mock, select a single book in the application."""
+    book_title = "Designing Evolvable Web APIs with ASP.NET"
+    page.route(
+        "**/BookStore/v1/Books",
+        lambda route: route.fulfill(path="./data/books.json")
+    )
+    page.goto("https://demoqa.com/books")
+    book = page.wait_for_selector(
+        f"a >> text={book_title}"
+    )
+    book.click()
+    visible = page.wait_for_selector(
+        f"label >> text={book_title}"
+    ).is_visible()
+    assert visible

--- a/tests/sauceDemo/api/test_books.py
+++ b/tests/sauceDemo/api/test_books.py
@@ -4,6 +4,7 @@ from playwright.sync_api import Playwright, sync_playwright, Page, APIRequestCon
 from sauceUtils.data import SauceDemoData
 
 """TESTING WITH MOCK API"""
+booksURL = 'https://demoqa.com/books'
 def test_select_single_book(page):
     """Using a mock, select a single book in the application."""
     book_title = "Designing Evolvable Web APIs with ASP.NET"
@@ -11,7 +12,7 @@ def test_select_single_book(page):
         "**/BookStore/v1/Books",
         lambda route: route.fulfill(path="./data/books.json")
     )
-    page.goto("https://demoqa.com/books")
+    page.goto(booksURL)
     book = page.wait_for_selector(
         f"a >> text={book_title}"
     )
@@ -19,4 +20,9 @@ def test_select_single_book(page):
     visible = page.wait_for_selector(
         f"label >> text={book_title}"
     ).is_visible()
+
     assert visible
+
+    with page.expect_response("**/BookStore/v1/Books") as response:
+        page.goto(booksURL)
+    assert response.value.ok

--- a/tests/sauceDemo/api/test_page_request.py
+++ b/tests/sauceDemo/api/test_page_request.py
@@ -1,0 +1,23 @@
+import pytest
+from typing import Generator
+from playwright.sync_api import Playwright, sync_playwright, Page, APIRequestContext, expect
+from sauceUtils.data import SauceDemoData
+import sys
+  
+
+def test_network_response(page: Page) -> None:
+    """Pulls in all requests from a given url"""
+    
+    DemoURL = 'https://demoqa.com/books'
+    # Subscribe to "request" and "response" events.
+    page.on("request", lambda request: print(">>", request.method, request.url))
+    page.on("response", lambda response: print("<<", response.status, response.url))
+    
+    #RESPONSE CLEAN-UP
+    page.route("**/*.jpg", lambda route: route.abort())
+    page.route("**/*.js", lambda route: route.abort())
+    page.route("**/*.png", lambda route: route.abort())
+    page.route("**/*.css", lambda route: route.abort())
+    page.route("**/*.woff2", lambda route: route.abort())
+    page.route("**/*.min.css", lambda route: route.abort())
+    page.goto(DemoURL)


### PR DESCRIPTION
**Scope**
Quick demo using mock data to test an endpoint (credit: Jonathan Thompson)
source: https://thompson-jonm.medium.com/intercepting-network-requests-with-python-and-playwright-7f621ad3935b

Features:
- [x] Pulls in data from a mock endpoint serving as json response
- [x] Compares a found title on the page to the response. title
- [x] Expects a 200 response

The framework is set up such that this test / data file can match any new bit of information 